### PR TITLE
Use inbound file list, add support for more codo command line options

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,11 +21,12 @@ var gulp = require('gulp'),
     codo = require('gulp-codo');
 
 gulp.task('doc', function () {
-	return gulp.src('*.coffee')
+	return gulp.src('*.coffee', {read: false})
 	.pipe(codo({
 		name: 'Greeter',
 		title: 'Greeter documentation',
-		readme: 'greeter.md'
+		readme: 'greeter.md',
+		extra: 'LICENSE.md'
 	}));
 });
 ```
@@ -37,3 +38,9 @@ gulp.task('doc', function () {
   * **title: string** : Title for generated documentation (e.g. *Greeter documentation*).
   * **readme: string**: : Readme to use for generated documentation (e.g. *greeter.md*).
   * **dir: string** : Output directory for documentation (e.g. *./doc*).
+	* **theme: string** : The theme to be used (e.g. *default*).
+	* **undocumented: boolean** : List undocumented objects
+	* **closure: boolean** : Try to parse closure-like block comments
+	* **private: boolean** : Show privates
+	* **verbose: boolean** : Show parsing errors
+	* **extra: string or Array** : Add extra files (e.g. *['LICENSE.md']*)

--- a/index.js
+++ b/index.js
@@ -3,28 +3,42 @@ var gutil = require('gulp-util'),
   through = require('through2'),
      exec = require('child_process').exec;
 
-function invokeCodo(file, opts, cb) {
-  var options = '';
+function invokeCodo(files, opts, cb) {
+  var options = 'codo ';
   if(opts.hasOwnProperty('name')) options += ' --name "' + opts.name + '"';
   if(opts.hasOwnProperty('title')) options += ' --title "' + opts.title + '"';
   if(opts.hasOwnProperty('readme')) options += ' --readme ' + opts.readme;
   if(opts.hasOwnProperty('dir')) options += ' --output ' + opts.dir;
-  return cb(null, exec('codo ' + options, function(){}));
+  if(opts.hasOwnProperty('theme')) options += ' --theme ' + opts.theme;
+  if(opts.undocumented) options += ' --undocumented';
+  if(opts.closure) options += ' --closure';
+  if(opts.private) options += ' --private';
+  if(opts.verbose) options += ' --verbose';
+  options += ' ' + files.map(function(f){ return f.path; }).join(' ');
+  if(opts.hasOwnProperty('extra')) {
+    var extra = opts.extra;
+    if (!Array.isArray(extra)) extra = [extra];
+    options += ' - ' + extra.join(' ');
+  }
+  if(opts.verbose) gutil.log('codo cmd:', options);
+  return exec(options, function(error, stdout, stderr) {
+    if (stdout) { gutil.log('\n' + stdout); }
+    if (stderr) { gutil.log('\n' + stderr); }
+    cb(error);
+  });
 }
 
 module.exports = function(options) {
+  var files = [];
   return through.obj(function(file, enc, cb) {
-    if(file.isNull()) {
-      cb(null);
-      return;
-    }
-
     if(file.isStream()) {
       cb(new gutil.PluginError('gulp-codo', 'Streaming not supported'));
       return;
     }
-
-    invokeCodo(file.path, options, function(err) {
+    files.push(file);
+    cb(null);
+  }, function (cb) {
+    invokeCodo(files, options, function(err) {
       if(err) {
         cb(new gutil.PluginError('gulp-codo', err, {fileName: file.path}));
         return;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
     "name": "Sam Saint-Pettersen",
     "email": "s.stpettersen+github@gmail.com"
   },
+  "contributors": [
+    {
+      "name": "Joe Hildebrand",
+      "email": "joe-github@cursive.net"
+    }
+  ],
   "engines": {
     "node": ">=0.10.0"
   },


### PR DESCRIPTION
Your code currently pulls in *_/_.coffee (the codo default) instead of using the file list passed in.  This PR fixes that, and adds support for all of the other interesting command line options from codo.
